### PR TITLE
Fix more warnings.

### DIFF
--- a/avi20.autopkg
+++ b/avi20.autopkg
@@ -10,7 +10,7 @@ nuget
    nuspec
    {
       id = avi20;
-      version: 1.1.0.0;
+      version: 1.2.0.0;
       title: AVI20 Library;
       authors: { TechSmith Corporation };
       owners: { TechSmith Corporation };

--- a/include/AVI20/Namespace.h
+++ b/include/AVI20/Namespace.h
@@ -11,7 +11,7 @@
 
 // Set up DLL Export/Import macro for windows
 #if !defined(AVI20_API)
-#ifdef _WIN32
+#if defined(_WIN32) && defined(_USRDLL)
 #ifdef AVI20_EXPORTS
 #define AVI20_API __declspec(dllexport)
 #else


### PR DESCRIPTION
Before when building GoTREC I would see the following warnings:
![locallydefinedsymbol](https://cloud.githubusercontent.com/assets/3475163/11788274/2f63a59e-a25e-11e5-8a8c-5e1bc9c05a1b.png)

I believe it is because these methods are marked as exported; which makes sense for DLL output; but it is used as a static lib.
