### PR TITLE
Allow for structured storage streams

### DIFF
--- a/avi20.autopkg
+++ b/avi20.autopkg
@@ -10,7 +10,7 @@ nuget
    nuspec
    {
       id = avi20;
-      version: 1.4.0-pre1;
+      version: 1.4.0;
       title: AVI20 Library;
       authors: { TechSmith Corporation };
       owners: { TechSmith Corporation };

--- a/avi20.autopkg
+++ b/avi20.autopkg
@@ -10,7 +10,7 @@ nuget
    nuspec
    {
       id = avi20;
-      version: 1.4.0.0;
+      version: 1.4.0-pre1;
       title: AVI20 Library;
       authors: { TechSmith Corporation };
       owners: { TechSmith Corporation };

--- a/avi20.autopkg
+++ b/avi20.autopkg
@@ -10,7 +10,7 @@ nuget
    nuspec
    {
       id = avi20;
-      version: 1.3.0.0;
+      version: 1.4.0.0;
       title: AVI20 Library;
       authors: { TechSmith Corporation };
       owners: { TechSmith Corporation };
@@ -20,7 +20,10 @@ nuget
       requireLicenseAcceptance: false;
       summary: AVI20 Library;
       releaseNotes: "Updated to Visual Studio 2017";
-      description: @"Library for reading and writing AVI 2.0 files (which supports files larger than 4GB) ";
+      description: @"Library for reading and writing AVI 2.0 files (which supports files larger than 4GB)";
+	  releaseNotes: "
+	     1.4.0.0   Allow for either std::istream or Windows-specific IStream implementations of file streams
+		 1.3.0.0   Updated to Visual Studio 2017";
       copyright: "Copyright (c) 2015-2018 TechSmith Corporation. All rights reserved.";
       tags: { native, tsc, vs2017, cpp, nomfc, techsmith, cross-platform };
    };

--- a/avi20.vcxproj
+++ b/avi20.vcxproj
@@ -157,6 +157,7 @@
     <ClInclude Include="include\AVI20\Read\ChunkHeader.h" />
     <ClInclude Include="include\AVI20\Read\FillAVIIndexInfo.h" />
     <ClInclude Include="include\AVI20\Read\FrameIndex.h" />
+    <ClInclude Include="include\AVI20\Read\IStream.h" />
     <ClInclude Include="include\AVI20\Read\MediaStreamInfo.h" />
     <ClInclude Include="include\AVI20\Read\MediaStreamReader.h" />
     <ClInclude Include="include\AVI20\Read\MediaStreamReaderImpl.h" />
@@ -164,6 +165,7 @@
     <ClInclude Include="include\AVI20\Read\Reader.h" />
     <ClInclude Include="include\AVI20\Read\Stream.h" />
     <ClInclude Include="include\AVI20\Read\StreamPosRestorer.h" />
+    <ClInclude Include="include\AVI20\Read\WindowsStream.h" />
     <ClInclude Include="include\AVI20\Tools\Tools.h" />
     <ClInclude Include="include\AVI20\Utl.h" />
     <ClInclude Include="include\AVI20\WaveFormatEx.h" />
@@ -188,6 +190,7 @@
     <ClCompile Include="src\Read\Reader.cpp" />
     <ClCompile Include="src\Read\Stream.cpp" />
     <ClCompile Include="src\Read\StreamPosRestorer.cpp" />
+    <ClCompile Include="src\Read\WindowsStream.cpp" />
     <ClCompile Include="src\Tools\Tools.cpp" />
     <ClCompile Include="src\Utl.cpp" />
     <ClCompile Include="src\WaveFormatEx.cpp" />

--- a/avi20.vcxproj.filters
+++ b/avi20.vcxproj.filters
@@ -93,6 +93,12 @@
     <ClInclude Include="include\AVI20\Write\Writer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\AVI20\Read\IStream.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\AVI20\Read\WindowsStream.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\Buffer.cpp">
@@ -156,6 +162,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\Write\Writer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Read\WindowsStream.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/include/AVI20/Read/ChunkHeader.h
+++ b/include/AVI20/Read/ChunkHeader.h
@@ -7,7 +7,7 @@
 
 NAMESPACE_AVI20_READ_BEGIN
 
-class Stream;
+class IStream;
 
 struct ChunkHeader
 {
@@ -25,7 +25,7 @@ struct ChunkHeader
    bool IsValid() const { return fcc != 0; }
 
    static bool IsList( uint32_t fcc ) { return fcc == FCC('RIFF') || fcc == FCC('LIST'); }
-   static ChunkHeader Read( Stream& stream );
+   static ChunkHeader Read( IStream& stream );
    static ChunkHeader Invalid();
 };
 

--- a/include/AVI20/Read/FillAVIIndexInfo.h
+++ b/include/AVI20/Read/FillAVIIndexInfo.h
@@ -8,6 +8,8 @@
 
 NAMESPACE_AVI20_READ_BEGIN
 
+class IStream;
+
 struct Index
 {
    Index() {}
@@ -62,7 +64,7 @@ struct FillAVIIndexInfo
    std::vector<ChunkHeader>   _AVIchs;
    std::vector<ChunkHeader>   _MOVIchs;
 
-   void InitFrom( Stream& stream );
+   void InitFrom( IStream& stream );
    void InitFrom( const std::string& filename );
 };
 

--- a/include/AVI20/Read/FrameIndex.h
+++ b/include/AVI20/Read/FrameIndex.h
@@ -10,13 +10,13 @@ NAMESPACE_AVI20_END
 
 NAMESPACE_AVI20_READ_BEGIN
 
-class Stream;
+class IStream;
 struct Type2Index;
 
 class FrameIndex
 {
 public:
-   FrameIndex( Stream& stream, const ChunkHeader& indxChunk );
+   FrameIndex( IStream& stream, const ChunkHeader& indxChunk );
    virtual ~FrameIndex();
 
    uint32_t       NumFrames() const;
@@ -41,7 +41,7 @@ private:
    void Parse();
 
 private:
-   Stream&     _Stream;
+   IStream&    _Stream;
    ChunkHeader _IndxChunk;
    Type2Index* _Type2Index;
 };

--- a/include/AVI20/Read/IStream.h
+++ b/include/AVI20/Read/IStream.h
@@ -7,17 +7,6 @@
 
 #include <stdint.h>
 
-NAMESPACE_AVI20_BEGIN
-struct AVISTDINDEX;
-struct AVISTDINDEX_ENTRY;
-struct AVISUPERINDEX;
-struct AVISUPERINDEXENTRY;
-struct BITMAPINFOHEADER;
-struct MainHeader;
-struct MediaStreamHeader;
-struct WAVEFORMATEX;
-NAMESPACE_AVI20_END
-
 NAMESPACE_AVI20_READ_BEGIN
 
 class IStream
@@ -25,18 +14,9 @@ class IStream
 public:
    virtual bool IsNULL() const = 0;
 
-   //template<class T> virtual T Read() = 0;
-   virtual void Read( uint32_t& d ) = 0;
-   virtual void Read( AVI20::AVISTDINDEX& d ) = 0;
-   virtual void Read( AVI20::AVISTDINDEX_ENTRY& d ) = 0;
-   virtual void Read( AVI20::AVISUPERINDEX& d ) = 0;
-   virtual void Read( AVI20::AVISUPERINDEXENTRY& d ) = 0;
-   virtual void Read( AVI20::BITMAPINFOHEADER& d ) = 0;
-   virtual void Read( AVI20::MainHeader& d ) = 0;
-   virtual void Read( AVI20::MediaStreamHeader& d ) = 0;
-   virtual void Read( AVI20::WAVEFORMATEX& d ) = 0;
-
+   template<typename T> void Read( T& t ) { Read( (uint8_t *)&t, sizeof( T ) ); }
    virtual bool Read( uint8_t* dest, uint64_t size ) = 0;
+
    virtual uint64_t Pos() = 0;
    virtual void SetPos( uint64_t pos ) = 0;
    virtual void SetPosToEnd() = 0;

--- a/include/AVI20/Read/IStream.h
+++ b/include/AVI20/Read/IStream.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <AVI20/AVI20Defs.h>
+#include <AVI20/Namespace.h>
+
+#include <exception>
+
+#include <stdint.h>
+
+NAMESPACE_AVI20_BEGIN
+struct AVISTDINDEX;
+struct AVISTDINDEX_ENTRY;
+struct AVISUPERINDEX;
+struct AVISUPERINDEXENTRY;
+struct BITMAPINFOHEADER;
+struct MainHeader;
+struct MediaStreamHeader;
+struct WAVEFORMATEX;
+NAMESPACE_AVI20_END
+
+NAMESPACE_AVI20_READ_BEGIN
+
+class IStream
+{
+public:
+   virtual bool IsNULL() const = 0;
+
+   //template<class T> virtual T Read() = 0;
+   virtual void Read( uint32_t& d ) = 0;
+   virtual void Read( AVI20::AVISTDINDEX& d ) = 0;
+   virtual void Read( AVI20::AVISTDINDEX_ENTRY& d ) = 0;
+   virtual void Read( AVI20::AVISUPERINDEX& d ) = 0;
+   virtual void Read( AVI20::AVISUPERINDEXENTRY& d ) = 0;
+   virtual void Read( AVI20::BITMAPINFOHEADER& d ) = 0;
+   virtual void Read( AVI20::MainHeader& d ) = 0;
+   virtual void Read( AVI20::MediaStreamHeader& d ) = 0;
+   virtual void Read( AVI20::WAVEFORMATEX& d ) = 0;
+
+   virtual bool Read( uint8_t* dest, uint64_t size ) = 0;
+   virtual uint64_t Pos() = 0;
+   virtual void SetPos( uint64_t pos ) = 0;
+   virtual void SetPosToEnd() = 0;
+   virtual uint64_t Size() = 0;
+   virtual bool IsGood() const = 0;
+   virtual void Rewind() = 0;
+
+   static void ThrowException() { throw std::exception(); }
+};
+
+NAMESPACE_AVI20_READ_END

--- a/include/AVI20/Read/MediaStreamReaderImpl.h
+++ b/include/AVI20/Read/MediaStreamReaderImpl.h
@@ -10,13 +10,13 @@ NAMESPACE_AVI20_END
 NAMESPACE_AVI20_READ_BEGIN
 
 struct MediaStreamInfo;
-class Stream;
+class IStream;
 class FrameIndex;
 
 class MediaStreamReaderImpl
 {
 public:
-   MediaStreamReaderImpl( Stream& stream, const MediaStreamInfo& indxChunk );
+   MediaStreamReaderImpl( IStream& stream, const MediaStreamInfo& indxChunk );
    virtual ~MediaStreamReaderImpl();
    void ParseIndex();
 
@@ -34,7 +34,7 @@ public:
    double          Duration() const;
 
 private:
-   Stream&         _Stream;
+   IStream&        _Stream;
    MediaStreamInfo _StreamInfo;
    FrameIndex*     _FrameIndex;
 };

--- a/include/AVI20/Read/ParserBase.h
+++ b/include/AVI20/Read/ParserBase.h
@@ -8,15 +8,15 @@
 NAMESPACE_AVI20_READ_BEGIN
 
 struct ChunkHeader;
-class Stream;
+class IStream;
 
 class ParserBase
 {
 public:
    ParserBase();
-   ParserBase( Stream& stream );
+   ParserBase( IStream& stream );
    void Parse();
-   void Parse( Stream& stream );
+   void Parse( IStream& stream );
    void ParseChunk( int depth );
 
 private:
@@ -38,7 +38,7 @@ protected:
    virtual std::string DebugStr( int depth, const ChunkHeader& ch, bool skip );
 
 protected:
-   Stream* _Stream;
+   IStream* _Stream;
 
 protected:
    MainHeader                   _MainHeader;

--- a/include/AVI20/Read/Reader.h
+++ b/include/AVI20/Read/Reader.h
@@ -7,13 +7,13 @@ NAMESPACE_AVI20_READ_BEGIN
 struct MediaStreamInfo;
 class ReaderImpl;
 class MediaStreamReader;
-class Stream;
+class IStream;
 
 class Reader
 {
 public:
    Reader();
-   Reader( Stream& stream );
+   Reader( IStream& stream );
    virtual ~Reader();
 
    int               NumStreams() const;

--- a/include/AVI20/Read/Stream.h
+++ b/include/AVI20/Read/Stream.h
@@ -19,16 +19,6 @@ public:
 
    bool IsNULL() const override;
 
-   void Read( uint32_t& result ) override { result = read<uint32_t>(); }
-   void Read( AVI20::AVISTDINDEX& result ) override { result = read <AVI20::AVISTDINDEX>(); }
-   void Read( AVI20::AVISTDINDEX_ENTRY& result ) override { result = read<AVI20::AVISTDINDEX_ENTRY>(); }
-   void Read( AVI20::AVISUPERINDEX& result ) override { result = read<AVI20::AVISUPERINDEX>(); }
-   void Read( AVI20::AVISUPERINDEXENTRY& result ) override { result = read<AVI20::AVISUPERINDEXENTRY>(); }
-   void Read( AVI20::BITMAPINFOHEADER& result ) override { result = read<AVI20::BITMAPINFOHEADER>(); }
-   void Read( AVI20::MainHeader& result ) override { result = read<AVI20::MainHeader>(); }
-   void Read( AVI20::MediaStreamHeader& result ) override { result = read<AVI20::MediaStreamHeader>(); }
-   void Read( AVI20::WAVEFORMATEX& result ) override { result = read<AVI20::WAVEFORMATEX>(); }
-
    bool Read( uint8_t* dest, uint64_t size ) override;
    uint64_t Pos() override;
    void SetPos( uint64_t pos ) override;

--- a/include/AVI20/Read/StreamPosRestorer.h
+++ b/include/AVI20/Read/StreamPosRestorer.h
@@ -4,14 +4,14 @@
 
 NAMESPACE_AVI20_READ_BEGIN
 
-class Stream;
+class IStream;
 
 struct StreamPosRestorer
 {
-   StreamPosRestorer( Stream& s );
+   StreamPosRestorer( IStream& s );
    ~StreamPosRestorer();
-   Stream&  _Stream;
-   uint64_t _Pos;
+   IStream&  _Stream;
+   uint64_t  _Pos;
 };
 
 NAMESPACE_AVI20_READ_END

--- a/include/AVI20/Read/WindowsStream.h
+++ b/include/AVI20/Read/WindowsStream.h
@@ -3,19 +3,14 @@
 #include <AVI20/AVI20Types.h>
 #include <AVI20/Read/IStream.h>
 
-#include <istream>
-
-NAMESPACE_AVI20_WRITE_BEGIN
-class Stream;
-NAMESPACE_AVI20_WRITE_END
+struct IStream;
 
 NAMESPACE_AVI20_READ_BEGIN
 
-class AVI20_API Stream : public IStream
+class WindowsStream : public IStream
 {
 public:
-   Stream( std::istream* file = NULL ) : _File( file ), /*_Stream(nullptr),*/ _CachedSize( -1 )/*, _CachedPos( 0ULL)*/ {}
-   Stream( Write::Stream& stream );
+   WindowsStream( ::IStream *stream ) :_Stream( stream ), _CachedSize( -1 ), _CachedPos( 0ULL ) {}
 
    bool IsNULL() const override;
 
@@ -38,16 +33,16 @@ public:
    void Rewind() override;
 
 private:
-
    template <typename T>
    T read()
    {
       T t;
-      _File->read( (char *)&t, sizeof( T ) );
+      Read( (uint8_t *)&t, sizeof( T ) );
       return t;
    }
-   std::istream* _File; // doesn't own
-   int64_t       _CachedSize;
-};
 
+   ::IStream*    _Stream;  // doesn't own
+   int64_t       _CachedSize;
+   uint64_t      _CachedPos;
+};
 NAMESPACE_AVI20_READ_END

--- a/include/AVI20/Read/WindowsStream.h
+++ b/include/AVI20/Read/WindowsStream.h
@@ -14,16 +14,6 @@ public:
 
    bool IsNULL() const override;
 
-   void Read( uint32_t& result ) override { result = read<uint32_t>(); }
-   void Read( AVI20::AVISTDINDEX& result ) override { result = read <AVI20::AVISTDINDEX>(); }
-   void Read( AVI20::AVISTDINDEX_ENTRY& result ) override { result = read<AVI20::AVISTDINDEX_ENTRY>(); }
-   void Read( AVI20::AVISUPERINDEX& result ) override { result = read<AVI20::AVISUPERINDEX>(); }
-   void Read( AVI20::AVISUPERINDEXENTRY& result ) override { result = read<AVI20::AVISUPERINDEXENTRY>(); }
-   void Read( AVI20::BITMAPINFOHEADER& result ) override { result = read<AVI20::BITMAPINFOHEADER>(); }
-   void Read( AVI20::MainHeader& result ) override { result = read<AVI20::MainHeader>(); }
-   void Read( AVI20::MediaStreamHeader& result ) override { result = read<AVI20::MediaStreamHeader>(); }
-   void Read( AVI20::WAVEFORMATEX& result ) override { result = read<AVI20::WAVEFORMATEX>(); }
-
    bool Read( uint8_t* dest, uint64_t size ) override;
    uint64_t Pos() override;
    void SetPos( uint64_t pos ) override;

--- a/include/AVI20/WaveFormatEx.h
+++ b/include/AVI20/WaveFormatEx.h
@@ -6,7 +6,7 @@
 
 NAMESPACE_AVI20_READ_BEGIN
 
-class Stream;
+class IStream;
 
 NAMESPACE_AVI20_READ_END
 
@@ -31,8 +31,8 @@ public:
    static WaveFormatEx PCM( int sampleRate, int bitDepth, int numChannels );
 
 public:
-   void InitFromStream( Read::Stream& stream );
-   static WaveFormatEx FromStream( Read::Stream& stream );
+   void InitFromStream( Read::IStream& stream );
+   static WaveFormatEx FromStream( Read::IStream& stream );
    void WriteToStream( Write::Stream& stream ) const;
 
 public:

--- a/src/Read/ChunkHeader.cpp
+++ b/src/Read/ChunkHeader.cpp
@@ -1,5 +1,5 @@
 #include <AVI20/Read/ChunkHeader.h>
-#include <AVI20/Read/Stream.h>
+#include <AVI20/Read/IStream.h>
 #include <AVI20/Utl.h>
 #include <cstring> // memset
 
@@ -7,15 +7,18 @@ NAMESPACE_AVI20_READ_BEGIN
 
 std::string ChunkHeader::Name() const { return FCCtoString( fcc ); }
 
-ChunkHeader ChunkHeader::Read( Stream& stream )
+ChunkHeader ChunkHeader::Read( IStream& stream )
 {
    ChunkHeader ret;
    ret.startPos = stream.Pos();
-   ret.fcc      = stream.Read<uint32_t>();
-   ret.size     = stream.Read<uint32_t>();
+   //ret.fcc      = stream.Read<uint32_t>();
+   //ret.size     = stream.Read<uint32_t>();
+   stream.Read( ret.fcc );
+   stream.Read( ret.size );
    ret.isList   = ChunkHeader::IsList( ret.fcc );
    if ( ret.isList )
-      ret.fcc = stream.Read<uint32_t>();
+      //ret.fcc = stream.Read<uint32_t>();
+      stream.Read( ret.fcc );
    return ret;
 }
 

--- a/src/Read/MediaStreamReaderImpl.cpp
+++ b/src/Read/MediaStreamReaderImpl.cpp
@@ -4,7 +4,7 @@
 
 NAMESPACE_AVI20_READ_BEGIN
 
-MediaStreamReaderImpl::MediaStreamReaderImpl( Stream& stream, const MediaStreamInfo& streamInfo )
+MediaStreamReaderImpl::MediaStreamReaderImpl( IStream& stream, const MediaStreamInfo& streamInfo )
    : _Stream( stream )
    , _StreamInfo( streamInfo )
 {

--- a/src/Read/ParserBase.cpp
+++ b/src/Read/ParserBase.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 #include <AVI20/AVI20Types.h>
 #include <AVI20/Read/ParserBase.h>
-#include <AVI20/Read/Stream.h>
+#include <AVI20/Read/IStream.h>
 #include <AVI20/Read/ChunkHeader.h>
 #include <AVI20/Read/StreamPosRestorer.h>
 #include <AVI20/Utl.h>
@@ -20,7 +20,7 @@ ParserBase::ParserBase()
 {
 }
 
-ParserBase::ParserBase( Stream& stream )
+ParserBase::ParserBase( IStream& stream )
    : _Stream( &stream )
 {
 }
@@ -31,7 +31,7 @@ void ParserBase::Parse()
    ParseChunk( 0 );
 }
 
-void ParserBase::Parse( Stream& stream )
+void ParserBase::Parse( IStream& stream )
 {
    _Stream = &stream;
    _Stream->SetPos( 0 );
@@ -98,9 +98,9 @@ void ParserBase::GotChunk( const ChunkHeader& ch )
 {
    if ( ch.fcc == FCC('avih') )
    {
-      _MainHeader = _Stream->Read<MainHeader>();
+      _Stream->Read( _MainHeader );
       if ( _MainHeader.dwStreams > 50 )
-         Stream::ThrowException();
+         IStream::ThrowException();
    }
 
    if ( ch.fcc == FCC('strl') )
@@ -110,13 +110,13 @@ void ParserBase::GotChunk( const ChunkHeader& ch )
 
    if ( ch.fcc == FCC('strh') && ch.size == sizeof(MediaStreamHeader) && !_StreamInfo.empty() )
    {
-      _StreamInfo.back().header = _Stream->Read<MediaStreamHeader>();
+      _Stream->Read( _StreamInfo.back().header );
    }
 
    if ( ch.fcc == FCC('strf') && !_StreamInfo.empty() )
    {
       if ( _StreamInfo.back().header.fccType == streamtypeVIDEO && ch.size == sizeof(BITMAPINFOHEADER) )
-         _StreamInfo.back().video = _Stream->Read<BITMAPINFOHEADER>();
+         _Stream->Read( _StreamInfo.back().video );
       if ( _StreamInfo.back().header.fccType == streamtypeAUDIO && ch.size >= sizeof(WAVEFORMATEX) )
          _StreamInfo.back().audio = WaveFormatEx::FromStream( *_Stream );
    }

--- a/src/Read/Reader.cpp
+++ b/src/Read/Reader.cpp
@@ -19,7 +19,7 @@ NAMESPACE_AVI20_READ_BEGIN
 class BasicInfoParser : public ParserBase
 {
 public:
-   BasicInfoParser( Stream& stream ) : ParserBase( stream ) {}
+   BasicInfoParser( IStream& stream ) : ParserBase( stream ) {}
 
    bool SkipChunk( const ChunkHeader& ch ) { return ch.fcc == FCC('movi'); }
 };
@@ -27,7 +27,7 @@ public:
 class ReaderImpl
 {
 public:
-   ReaderImpl( Stream& stream )
+   ReaderImpl( IStream& stream )
       : _Stream( stream )
       , _Parser( stream )
    {
@@ -106,7 +106,7 @@ public:
    }
 
 private:
-   Stream&                             _Stream;
+   IStream&                             _Stream;
    std::vector<MediaStreamReaderImpl*> _StreamReader;
    BasicInfoParser                     _Parser;
 };
@@ -122,7 +122,7 @@ Reader::~Reader()
    delete _Impl;
 }
 
-Reader::Reader( Stream& stream )
+Reader::Reader( IStream& stream )
 {
    _Impl = new ReaderImpl( stream );
 }

--- a/src/Read/Stream.cpp
+++ b/src/Read/Stream.cpp
@@ -10,14 +10,52 @@ Stream::Stream( Write::Stream& stream )
 {
 }
 
+bool Stream::IsNULL() const
+{
+   return _File == nullptr;
+}
+
+bool Stream::Read( uint8_t* dest, uint64_t size )
+{
+   _File->read( (char*)dest, size );
+   return _File->good();
+}
+
+uint64_t Stream::Pos()
+{
+   return _File->tellg();
+}
+
+void Stream::SetPos( uint64_t pos )
+{
+   _File->seekg( pos );
+}
+
+void Stream::SetPosToEnd()
+{
+   _File->seekg( 0, std::ios::end );
+}
+
 uint64_t Stream::Size()
 {
    if ( _CachedSize >= 0 )
-      return (uint64_t) _CachedSize;
+      return (uint64_t)_CachedSize;
+
    StreamPosRestorer restorer( *this );
    SetPosToEnd();
    _CachedSize = Pos();
    return _CachedSize;
+}
+
+bool Stream::IsGood() const
+{
+   return _File->good();
+}
+
+void Stream::Rewind()
+{
+   _File->clear();
+   SetPos( 0ULL );
 }
 
 NAMESPACE_AVI20_READ_END

--- a/src/Read/StreamPosRestorer.cpp
+++ b/src/Read/StreamPosRestorer.cpp
@@ -3,7 +3,7 @@
 
 NAMESPACE_AVI20_READ_BEGIN
 
-StreamPosRestorer::StreamPosRestorer( Stream& s )
+StreamPosRestorer::StreamPosRestorer( IStream& s )
    : _Stream( s )
 {
    _Pos = _Stream.Pos();

--- a/src/Read/WindowsStream.cpp
+++ b/src/Read/WindowsStream.cpp
@@ -1,0 +1,63 @@
+#include <AVI20/Read/WindowsStream.h>
+
+#include <ObjIdl.h>
+
+NAMESPACE_AVI20_READ_BEGIN
+
+bool WindowsStream::IsNULL() const
+{
+   return _Stream == nullptr;
+}
+
+bool WindowsStream::Read( uint8_t* dest, uint64_t size )
+{
+   ULONG nRead = 0;
+   HRESULT hr = _Stream->Read( dest, ULONG(size), &nRead );
+   _CachedPos += nRead;
+   return SUCCEEDED( hr ) && size == nRead;
+}
+
+uint64_t WindowsStream::Pos()
+{
+   return _CachedPos;
+}
+
+void WindowsStream::SetPos( uint64_t pos )
+{
+   LARGE_INTEGER liPos;
+   ULARGE_INTEGER uliPos;
+   liPos.QuadPart = int64_t( pos );
+   HRESULT hr = _Stream->Seek( liPos, STREAM_SEEK_SET, &uliPos );
+   if ( SUCCEEDED( hr ) )
+      _CachedPos = uliPos.QuadPart;
+}
+
+void WindowsStream::SetPosToEnd()
+{
+   SetPos( Size() );
+}
+
+uint64_t WindowsStream::Size()
+{
+   if ( _CachedSize >= 0 )
+      return (uint64_t)_CachedSize;
+
+   STATSTG statStg;
+   HRESULT hr = _Stream->Stat( &statStg, STATFLAG_NONAME );
+   if ( SUCCEEDED( hr ) )
+      _CachedSize = statStg.cbSize.QuadPart;
+
+   return _CachedSize;
+}
+
+bool WindowsStream::IsGood() const
+{
+   return _Stream != nullptr;
+}
+
+void WindowsStream::Rewind()
+{
+   SetPos( 0ULL );
+}
+
+NAMESPACE_AVI20_READ_END

--- a/src/WaveFormatEx.cpp
+++ b/src/WaveFormatEx.cpp
@@ -32,15 +32,15 @@ WaveFormatEx WaveFormatEx::PCM( int sampleRate, int bitDepth, int numChannels )
    return ret;
 }
 
-void WaveFormatEx::InitFromStream( Read::Stream& stream )
+void WaveFormatEx::InitFromStream( Read::IStream& stream )
 {
-   _Format = stream.Read<AVI20::WAVEFORMATEX>();
+   stream.Read( _Format );
    _ExtraData.resize( _Format.cbSize );
    if ( !_ExtraData.empty() )
       stream.Read( &_ExtraData[0], _Format.cbSize );
 }
 
-WaveFormatEx WaveFormatEx::FromStream( Read::Stream& stream )
+WaveFormatEx WaveFormatEx::FromStream( Read::IStream& stream )
 {
    WaveFormatEx ret;
    ret.InitFromStream( stream );


### PR DESCRIPTION
With this change, you can create a Read::Stream based on either a std::istream or a Windows-specific IStream object (which allows us to read streams out of camrec files).