### PR TITLE
Turn off whole program optimization

### DIFF
--- a/avi20.autopkg
+++ b/avi20.autopkg
@@ -14,7 +14,6 @@ nuget
       title: AVI20 Library;
       authors: { TechSmith Corporation };
       owners: { TechSmith Corporation };
-      licenseUrl: "http://www.techsmith.com";
       projectUrl: "https://github.com/TechSmith/AVI20";
       iconUrl: "http://www.techsmith.com/favicon.ico";
       requireLicenseAcceptance: false;

--- a/avi20.autopkg
+++ b/avi20.autopkg
@@ -10,7 +10,7 @@ nuget
    nuspec
    {
       id = avi20;
-      version: 1.5.1;
+      version: 1.6.0;
       title: AVI20 Library;
       authors: { TechSmith Corporation };
       owners: { TechSmith Corporation };
@@ -22,14 +22,15 @@ nuget
       releaseNotes: "Updated to Visual Studio 2017";
       description: @"Library for reading and writing AVI 2.0 files (which supports files larger than 4GB)";
 	  releaseNotes: "
+        1.6.0     Turn off Whole Program Optimization for Release builds
 	     1.5.1.0   Fix AVI 1.0 stream reading when there are multiple streams
 	     1.5.0.0   Allow for read of AVI 1.0 streams (for compatibility with old camrec files)
 	     1.4.0.0   Allow for either std::istream or Windows-specific IStream implementations of file streams
 		 1.3.0.0   Updated to Visual Studio 2017";
-      copyright: "Copyright (c) 2015-2018 TechSmith Corporation. All rights reserved.";
+      copyright: "Copyright (c) 2015-2020 TechSmith Corporation. All rights reserved.";
       tags: { native, tsc, vs2017, cpp, nomfc, techsmith, cross-platform };
    };
-   
+
    dependencies
    {
       packages:

--- a/avi20.vcxproj
+++ b/avi20.vcxproj
@@ -123,6 +123,7 @@
       <PreprocessorDefinitions>AVI20_EXPORTS;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(OutDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -141,6 +142,7 @@
       <PreprocessorDefinitions>AVI20_EXPORTS;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ProgramDataBaseFileName>$(OutDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
Addresses: https://github.com/TechSmith/CamtasiaWin/issues/12568

Whole Program Optimization is causing this error in Camtasia while trying to build with newer versions of Visual Studio.
```
LINK : fatal error C1047: The object or library file 'C:\src\CamtasiaWin\packages\avi20.1.5.1\build\native\..\..\\build\native\lib\x64\v141\Release\AVI20.lib' was created with an older compiler than other objects; rebuild old objects and libraries
LINK : fatal error LNK1257: code generation failed
```

The solution is to turn off Whole Program Optimization, which is a linker feature that requires the code being linked to have been compiled with the same compiler.